### PR TITLE
Update turbo.json with `topo`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,12 @@
       "dependsOn": ["^db:generate", "^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
-    "lint": {},
+    "topo": {
+      "dependsOn": ["^topo"]
+    },
+    "lint": {
+      "dependsOn": ["topo"]
+    },
     "dev": {
       "dependsOn": ["^db:generate"],
       "cache": false,


### PR DESCRIPTION
You can parallelize tasks that don't depend on each other using a dummy `topo` (or any other name) task!

You'll find this documented here: https://turbo.build/repo/docs/core-concepts/monorepos/task-dependencies#dependencies-outside-of-a-task

The same setup could be used for a `tsc` typechecking command, as well!